### PR TITLE
Invalid usage of `prettier/@typescript-eslint` configuration

### DIFF
--- a/packages/@arcticicestudio/eslint-config-typescript/rules/prettier/index.js
+++ b/packages/@arcticicestudio/eslint-config-typescript/rules/prettier/index.js
@@ -13,7 +13,7 @@
  * @see https://prettier.io
  */
 module.exports = {
-  extends: ["prettier", "prettier/@typescript-eslint"],
+  extends: ["prettier"],
   plugins: ["prettier"],
   rules: {
     /**


### PR DESCRIPTION
Resolves #49 