### PR TITLE
Allow `void` operator as a statement for React Hooks

### DIFF
--- a/packages/@arcticicestudio/eslint-config-base/rules/best-practices.js
+++ b/packages/@arcticicestudio/eslint-config-base/rules/best-practices.js
@@ -444,7 +444,12 @@ module.exports = {
      * Disallow `void` operators.
      * @see https://eslint.org/docs/rules/no-void
      */
-    "no-void": "error",
+    "no-void": [
+      "error",
+      {
+        allowAsStatement: true,
+      },
+    ],
     /**
      * Disallow specified warning terms in comments.
      * @see https://eslint.org/docs/rules/no-warning-comments


### PR DESCRIPTION
Resolves #55 